### PR TITLE
Add upgrade scripts

### DIFF
--- a/contracts/arbitrage/BancorArbitrage.sol
+++ b/contracts/arbitrage/BancorArbitrage.sol
@@ -228,7 +228,7 @@ contract BancorArbitrage is ReentrancyGuardUpgradeable, Utils, Upgradeable {
      * @inheritdoc Upgradeable
      */
     function version() public pure override(Upgradeable) returns (uint16) {
-        return 10;
+        return 11;
     }
 
     /**
@@ -385,7 +385,7 @@ contract BancorArbitrage is ReentrancyGuardUpgradeable, Utils, Upgradeable {
         Token finalToken,
         uint256 sourceAmount,
         uint256 value
-    ) private view {
+    ) private pure {
         // verify that the last token in the process is the arb token
         if (finalToken != token) {
             revert InvalidInitialAndFinalTokens();

--- a/deploy/scripts/base/0004-bancor-arbitrage-upgrade.ts
+++ b/deploy/scripts/base/0004-bancor-arbitrage-upgrade.ts
@@ -1,0 +1,44 @@
+import { DeployedContracts, InstanceName, setDeploymentMetadata, upgradeProxy } from '../../../utils/Deploy';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { BancorArbitrage } from '../../../typechain-types';
+
+const func: DeployFunction = async ({ getNamedAccounts }: HardhatRuntimeEnvironment) => {
+    const {
+        deployer,
+        bnt,
+        weth,
+        bancorNetworkV2,
+        bancorNetworkV3,
+        uniswapV2Router02,
+        sushiSwapRouter,
+        uniswapV3Router,
+        carbonController,
+        balancerVault,
+        carbonPOL
+    } = await getNamedAccounts();
+
+    const platforms: BancorArbitrage.PlatformsStruct = {
+        bancorNetworkV2,
+        bancorNetworkV3,
+        uniV2Router: uniswapV2Router02,
+        uniV3Router: uniswapV3Router,
+        sushiswapRouter: sushiSwapRouter,
+        carbonController,
+        balancerVault,
+        carbonPOL
+    };
+
+    const vault = await DeployedContracts.Vault.deployed();
+
+    // Deploy BancorArbitrage contract
+    await upgradeProxy({
+        name: InstanceName.BancorArbitrage,
+        from: deployer,
+        args: [bnt, weth, vault.address, platforms]
+    });
+
+    return true;
+};
+
+export default setDeploymentMetadata(__filename, func);

--- a/deploy/scripts/mainnet/0012-bancor-arbitrage-upgrade.ts
+++ b/deploy/scripts/mainnet/0012-bancor-arbitrage-upgrade.ts
@@ -1,0 +1,66 @@
+import { DeployedContracts, InstanceName, isMainnet, setDeploymentMetadata, upgradeProxy } from '../../../utils/Deploy';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { BancorArbitrage } from '../../../typechain-types';
+
+const func: DeployFunction = async ({ getNamedAccounts }: HardhatRuntimeEnvironment) => {
+    const {
+        deployer,
+        bnt,
+        weth,
+        protocolWallet,
+        bancorNetworkV2,
+        bancorNetworkV3,
+        uniswapV2Router02,
+        sushiSwapRouter,
+        uniswapV3Router,
+        carbonController,
+        balancerVault,
+        carbonPOL
+    } = await getNamedAccounts();
+
+    const platforms: BancorArbitrage.PlatformsStruct = {
+        bancorNetworkV2,
+        bancorNetworkV3,
+        uniV2Router: uniswapV2Router02,
+        uniV3Router: uniswapV3Router,
+        sushiswapRouter: sushiSwapRouter,
+        carbonController,
+        balancerVault,
+        carbonPOL
+    };
+
+    if (isMainnet()) {
+        await upgradeProxy({
+            name: InstanceName.BancorArbitrage,
+            from: deployer,
+            args: [bnt, weth, protocolWallet, platforms]
+        });
+    } else {
+        const mockExchanges = await DeployedContracts.MockExchanges.deployed();
+        const mockBalancerVault = await DeployedContracts.MockBalancerVault.deployed();
+
+        await upgradeProxy({
+            name: InstanceName.BancorArbitrage,
+            from: deployer,
+            args: [
+                bnt,
+                weth,
+                protocolWallet,
+                {
+                    bancorNetworkV2: mockExchanges.address,
+                    bancorNetworkV3,
+                    uniV2Router: mockExchanges.address,
+                    uniV3Router: mockExchanges.address,
+                    sushiswapRouter: mockExchanges.address,
+                    carbonController: mockExchanges.address,
+                    balancerVault: mockBalancerVault.address
+                }
+            ]
+        });
+    }
+
+    return true;
+};
+
+export default setDeploymentMetadata(__filename, func);

--- a/deploy/tests/base/0004-bancor-arbitrage.ts
+++ b/deploy/tests/base/0004-bancor-arbitrage.ts
@@ -1,0 +1,32 @@
+import { getNamedAccounts } from 'hardhat';
+import { BancorArbitrage, ProxyAdmin, Vault } from '../../../components/Contracts';
+import { DeployedContracts, describeDeployment } from '../../../utils/Deploy';
+import { toPPM, toWei } from '../../../utils/Types';
+import { Roles } from '../../../utils/Roles';
+import { expect } from 'chai';
+
+describeDeployment(__filename, () => {
+    let proxyAdmin: ProxyAdmin;
+    let bancorArbitrage: BancorArbitrage;
+    let vault: Vault;
+
+    beforeEach(async () => {
+        proxyAdmin = await DeployedContracts.ProxyAdmin.deployed();
+        bancorArbitrage = await DeployedContracts.BancorArbitrage.deployed();
+        vault = await DeployedContracts.Vault.deployed();
+    });
+
+    it('should deploy and configure the vault contract', async () => {
+        const { deployer } = await getNamedAccounts();
+        expect(await vault.hasRole(Roles.Upgradeable.ROLE_ADMIN, deployer)).to.be.true;
+    });
+
+    it('should deploy and configure the bancor arbitrage contract', async () => {
+        expect(await proxyAdmin.getProxyAdmin(bancorArbitrage.address)).to.equal(proxyAdmin.address);
+        expect(await bancorArbitrage.version()).to.equal(11);
+
+        const arbRewards = await bancorArbitrage.rewards();
+        expect(arbRewards.percentagePPM).to.equal(toPPM(50));
+        expect(arbRewards.maxAmount).to.equal(toWei(100));
+    });
+});

--- a/deploy/tests/mainnet/0012-bancor-arbitrage-upgrade.ts
+++ b/deploy/tests/mainnet/0012-bancor-arbitrage-upgrade.ts
@@ -1,0 +1,37 @@
+import { shouldHaveGap } from '../../../utils/Proxy';
+import { BancorArbitrage, ProxyAdmin } from '../../../components/Contracts';
+import { DeployedContracts, describeDeployment } from '../../../utils/Deploy';
+import { toPPM, toWei } from '../../../utils/Types';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+describeDeployment(__filename, () => {
+    let proxyAdmin: ProxyAdmin;
+    let bancorArbitrage: BancorArbitrage;
+
+    shouldHaveGap('BancorArbitrage', '_rewards');
+
+    beforeEach(async () => {
+        proxyAdmin = await DeployedContracts.ProxyAdmin.deployed();
+        bancorArbitrage = await DeployedContracts.BancorArbitrage.deployed();
+    });
+
+    it('should upgrade correctly', async () => {
+        expect(await proxyAdmin.getProxyAdmin(bancorArbitrage.address)).to.equal(proxyAdmin.address);
+        expect(await bancorArbitrage.version()).to.equal(11);
+        const implementationAddress = await proxyAdmin.getProxyImplementation(bancorArbitrage.address);
+        const bancorArbitrageImplementation: BancorArbitrage = await ethers.getContractAt(
+            'BancorArbitrage',
+            implementationAddress
+        );
+
+        const arbRewards = await bancorArbitrage.rewards();
+        expect(arbRewards.percentagePPM).to.equal(toPPM(50));
+        expect(arbRewards.maxAmount.toString()).to.equal(toWei(1000).toString());
+
+        // test implementation has been initialized
+        // hardcoding gas limit to avoid gas estimation attempts (which get rejected instead of reverted)
+        const tx = bancorArbitrageImplementation.initialize({ gasLimit: 6000000 });
+        await expect(await tx).to.be.reverted;
+    });
+});

--- a/test/BancorArbitrage.t.sol
+++ b/test/BancorArbitrage.t.sol
@@ -270,7 +270,7 @@ contract BancorArbitrageV2ArbsTest is Test {
      */
     function testShouldBeInitialized() public {
         uint256 version = bancorArbitrage.version();
-        assertEq(version, 10);
+        assertEq(version, 11);
     }
 
     /// --- Reward distribution and protocol transfer tests --- ///


### PR DESCRIPTION
* Add upgrade scripts for base and mainnet for BancorArbitrage v11 (`_validateFundAndArbParams` fix)